### PR TITLE
Ws server refactor

### DIFF
--- a/client/bootstrap_demo_currency.sh
+++ b/client/bootstrap_demo_currency.sh
@@ -5,17 +5,17 @@
 # bootstrap a bot currency on Encointer Cantillon Testnet
 
 # Cantillon node endpoint
-#NURL=wss://cantillon.encointer.org
-#NPORT=443
-## Cantillon worker endpoint
-#WURL=wss://substratee03.scs.ch
-#WPORT=443
+NURL=wss://cantillon.encointer.org
+NPORT=443
+# Cantillon worker endpoint
+WURL=wss://substratee03.scs.ch
+WPORT=443
 
 # locals
-NURL=ws://127.0.0.1
-NPORT=9991
-WURL=ws://127.0.0.1
-WPORT=2000
+#NURL=ws://127.0.0.1
+#NPORT=9991
+#WURL=ws://127.0.0.1
+#WPORT=2000
 
 CLIENT="./../bin/encointer-client-teeproxy -u $NURL -p $NPORT -U $WURL -P $WPORT"
 

--- a/client/bootstrap_demo_currency.sh
+++ b/client/bootstrap_demo_currency.sh
@@ -5,13 +5,19 @@
 # bootstrap a bot currency on Encointer Cantillon Testnet
 
 # Cantillon node endpoint
-NURL=wss://cantillon.encointer.org
-NPORT=443
-# Cantillon worker endpoint
-WURL=wss://substratee03.scs.ch
-WPORT=443
+#NURL=wss://cantillon.encointer.org
+#NPORT=443
+## Cantillon worker endpoint
+#WURL=wss://substratee03.scs.ch
+#WPORT=443
 
-CLIENT="./encointer-client -u $NURL -p $NPORT -U $WURL -P $WPORT"
+# locals
+NURL=ws://127.0.0.1
+NPORT=9991
+WURL=ws://127.0.0.1
+WPORT=2000
+
+CLIENT="./../bin/encointer-client-teeproxy -u $NURL -p $NPORT -U $WURL -P $WPORT"
 
 wait_for_phase() {
   current_phase=$($CLIENT get-phase)
@@ -45,7 +51,7 @@ wait_for_phase REGISTERING
 
 #read MRENCLAVE <<< $($CLIENT list-workers | awk '/  MRENCLAVE: / { print $2 }')
 #cid=7eLSZLSMShw4ju9GvuMmoVgeZxZimtvsGTSvLEdvcRqQ
-MRENCLAVE=HVmtypxe23ngaWWaRYmAtKWThuYeXL5V1nUALpQQvC3A
+MRENCLAVE=ATuyb9taa4cPmvH2yoZksNmopzYYZk3uc1RGXKJy9sqM
 
 echo "  MRENCLAVE = ${MRENCLAVE}"
 

--- a/stf/src/lib.rs
+++ b/stf/src/lib.rs
@@ -135,7 +135,7 @@ impl TrustedGetter {
     }
 }
 
-#[derive(Encode, Decode, Clone)]
+#[derive(Encode, Decode, Clone, Debug)]
 pub struct TrustedGetterSigned {
     pub getter: TrustedGetter,
     pub signature: AnySignature,
@@ -152,7 +152,7 @@ impl TrustedGetterSigned {
     }
 }
 
-#[derive(Encode, Decode, Clone)]
+#[derive(Encode, Decode, Clone, Debug)]
 pub struct TrustedCallSigned {
     pub call: TrustedCall,
     pub nonce: u32,

--- a/worker/src/ws_server.rs
+++ b/worker/src/ws_server.rs
@@ -54,11 +54,15 @@ pub fn start_ws_server(addr: String, worker: MpscSender<WsServerRequest>) {
                 "[WS Server] Forwarding message to worker event loop: {:?}",
                 msg
             );
-            let req: ClientRequest = Decode::decode(&mut msg.into_data().as_slice()).unwrap();
 
-            self.worker
-                .send(WsServerRequest::new(self.client.clone(), req))
-                .unwrap();
+            match ClientRequest::decode(&mut msg.into_data().as_slice()) {
+                Ok(req) => {
+                    self.worker
+                        .send(WsServerRequest::new(self.client.clone(), req))
+                        .unwrap();
+                }
+                Err(e) => self.client.send("Could not decode request").unwrap()
+            }
             Ok(())
         }
 

--- a/worker/src/ws_server.rs
+++ b/worker/src/ws_server.rs
@@ -20,37 +20,46 @@ use std::thread;
 
 use sgx_types::*;
 
-use codec::Encode;
+use codec::{Decode, Encode};
 use log::*;
-use substratee_stf::ShardIdentifier;
+use std::sync::mpsc::Sender as MpscSender;
+use substratee_stf::{ShardIdentifier, TrustedGetter, TrustedGetterSigned};
 use substratee_worker_api::requests::*;
 use ws::{listen, CloseCode, Handler, Message, Result, Sender};
 
 use crate::enclave::api::{enclave_query_state, enclave_shielding_key};
 
-pub fn start_ws_server(eid: sgx_enclave_id_t, addr: String, mu_ra_port: String) {
+#[derive(Clone, Debug)]
+pub struct WsServerRequest {
+    client: Sender,
+    request: ClientRequest,
+}
+
+impl WsServerRequest {
+    pub fn new(client: Sender, request: ClientRequest) -> Self {
+        return Self { client, request };
+    }
+}
+
+pub fn start_ws_server(addr: String, worker: MpscSender<WsServerRequest>) {
     // Server WebSocket handler
     struct Server {
-        out: Sender,
-        eid: sgx_enclave_id_t,
-        mu_ra_port: String,
+        client: Sender,
+        worker: MpscSender<WsServerRequest>,
     }
 
     impl Handler for Server {
         fn on_message(&mut self, msg: Message) -> Result<()> {
-            info!("     [WS Server] Got message '{}'. ", msg);
+            warn!(
+                "[WS Server] Forwarding message to worker event loop: {:?}",
+                msg
+            );
+            let req: ClientRequest = Decode::decode(&mut msg.into_data().as_slice()).unwrap();
 
-            let msg_txt = msg.into_text().unwrap();
-            let args: Vec<&str> = msg_txt.split("::").collect();
-
-            let answer = match args[0] {
-                MSG_GET_PUB_KEY_WORKER => get_worker_pub_key(self.eid),
-                MSG_GET_MU_RA_PORT => Message::text(self.mu_ra_port.clone()),
-                MSG_GET_STF_STATE => handle_get_stf_state_msg(self.eid, args[1], args[2]),
-                _ => Message::text("[WS Server]: unrecognized msg pattern"),
-            };
-
-            self.out.send(answer)
+            self.worker
+                .send(WsServerRequest::new(self.client.clone(), req))
+                .unwrap();
+            Ok(())
         }
 
         fn on_close(&mut self, code: CloseCode, reason: &str) {
@@ -61,20 +70,35 @@ pub fn start_ws_server(eid: sgx_enclave_id_t, addr: String, mu_ra_port: String) 
     info!("Starting WebSocket server on {}", addr);
     thread::spawn(move || {
         listen(addr, |out| Server {
-            out,
-            eid,
-            mu_ra_port: mu_ra_port.clone(),
+            client: out,
+            worker: worker.clone(),
         })
         .unwrap()
     });
 }
 
-fn handle_get_stf_state_msg(eid: sgx_enclave_id_t, getter_str: &str, shard_str: &str) -> Message {
-    info!("     [WS Server] Query state");
-    let getter_vec = hex::decode(getter_str).unwrap();
-    let shard = ShardIdentifier::from_slice(&hex::decode(shard_str).unwrap());
+pub fn handle_request(
+    req: WsServerRequest,
+    eid: sgx_enclave_id_t,
+    mu_ra_port: String,
+) -> Result<()> {
+    info!("     [WS Server] Got message '{:?}'. ", req);
+    let answer = match req.request {
+        ClientRequest::PubKeyWorker => get_pubkey(eid),
+        ClientRequest::MuRaPortWorker => Message::text(mu_ra_port),
+        ClientRequest::StfState(getter, shard) => get_stf_state(eid, getter, shard),
+    };
 
-    let value = match enclave_query_state(eid, getter_vec, shard.encode()) {
+    req.client.send(answer)
+}
+
+fn get_stf_state(
+    eid: sgx_enclave_id_t,
+    getter: TrustedGetterSigned,
+    shard: ShardIdentifier,
+) -> Message {
+    info!("     [WS Server] Query state");
+    let value = match enclave_query_state(eid, getter.encode(), shard.encode()) {
         Ok(val) => Some(val),
         Err(_) => {
             error!("query state failed");
@@ -86,7 +110,7 @@ fn handle_get_stf_state_msg(eid: sgx_enclave_id_t, getter_str: &str, shard_str: 
     Message::text(hex::encode(value.encode()))
 }
 
-fn get_worker_pub_key(eid: sgx_enclave_id_t) -> Message {
+fn get_pubkey(eid: sgx_enclave_id_t) -> Message {
     let rsa_pubkey = enclave_shielding_key(eid).unwrap();
     debug!("     [WS Server] RSA pubkey {:?}\n", rsa_pubkey);
 

--- a/worker/src/ws_server.rs
+++ b/worker/src/ws_server.rs
@@ -37,7 +37,7 @@ pub struct WsServerRequest {
 
 impl WsServerRequest {
     pub fn new(client: Sender, request: ClientRequest) -> Self {
-        return Self { client, request };
+        Self { client, request }
     }
 }
 
@@ -50,7 +50,7 @@ pub fn start_ws_server(addr: String, worker: MpscSender<WsServerRequest>) {
 
     impl Handler for Server {
         fn on_message(&mut self, msg: Message) -> Result<()> {
-            warn!(
+            info!(
                 "[WS Server] Forwarding message to worker event loop: {:?}",
                 msg
             );

--- a/worker/worker-api/src/client.rs
+++ b/worker/worker-api/src/client.rs
@@ -17,20 +17,21 @@
 
 use std::sync::mpsc::Sender as ThreadOut;
 
+use crate::requests::ClientRequest;
+use codec::Encode;
 use log::*;
 use ws::{CloseCode, Handler, Handshake, Message, Result, Sender};
 
 pub struct WsClient {
     pub out: Sender,
-    pub request: String,
+    pub request: ClientRequest,
     pub result: ThreadOut<String>,
 }
 
 impl Handler for WsClient {
     fn on_open(&mut self, _: Handshake) -> Result<()> {
-        info!("sending request: {}", self.request);
-
-        match self.out.send(self.request.clone()) {
+        debug!("sending request: {:?}", self.request);
+        match self.out.send(Message::Binary(self.request.encode())) {
             Ok(_) => Ok(()),
             Err(e) => Err(e),
         }

--- a/worker/worker-api/src/lib.rs
+++ b/worker/worker-api/src/lib.rs
@@ -15,7 +15,7 @@
 
 */
 
-use std::sync::mpsc::{channel, Receiver};
+use std::sync::mpsc::channel;
 use std::thread;
 
 use sgx_crypto_helper::rsa3072::Rsa3072PubKey;
@@ -37,10 +37,8 @@ pub struct Api {
 }
 
 impl Api {
-    pub fn new(url: String) -> Api {
-        Api {
-            url,
-        }
+    pub fn new(url: String) -> Self {
+        Self { url }
     }
 
     pub fn get_mu_ra_port(&self) -> Result<String, ()> {
@@ -62,10 +60,6 @@ impl Api {
         shard: &ShardIdentifier,
     ) -> Result<Vec<u8>, ()> {
         let req = ClientRequest::StfState(getter, shard.to_owned());
-        //
-        // let getter_str = hex::encode(getter.encode());
-        // let shard_str = hex::encode(shard.encode());
-        // let request = format!("{}::{}::{}", MSG_GET_STF_STATE, getter_str, shard_str);
         match Self::get(&self, req) {
             Ok(res) => {
                 let value_slice = hex::decode(&res).unwrap();

--- a/worker/worker-api/src/lib.rs
+++ b/worker/worker-api/src/lib.rs
@@ -15,12 +15,12 @@
 
 */
 
-use std::sync::mpsc::channel;
+use std::sync::mpsc::{channel, Receiver};
 use std::thread;
 
 use sgx_crypto_helper::rsa3072::Rsa3072PubKey;
 
-use codec::{Decode, Encode};
+use codec::{Decode};
 use log::*;
 use ws::connect;
 
@@ -44,11 +44,11 @@ impl Api {
     }
 
     pub fn get_mu_ra_port(&self) -> Result<String, ()> {
-        Self::get(&self, MSG_GET_MU_RA_PORT)
+        Self::get(&self, ClientRequest::MuRaPortWorker)
     }
 
     pub fn get_rsa_pubkey(&self) -> Result<Rsa3072PubKey, ()> {
-        let keystr = Self::get(&self, MSG_GET_PUB_KEY_WORKER)?;
+        let keystr = Self::get(&self, ClientRequest::PubKeyWorker)?;
 
         let rsa_pubkey: Rsa3072PubKey = serde_json::from_str(&keystr).unwrap();
         info!("[+] Got RSA public key of enclave");
@@ -61,10 +61,12 @@ impl Api {
         getter: TrustedGetterSigned,
         shard: &ShardIdentifier,
     ) -> Result<Vec<u8>, ()> {
-        let getter_str = hex::encode(getter.encode());
-        let shard_str = hex::encode(shard.encode());
-        let request = format!("{}::{}::{}", MSG_GET_STF_STATE, getter_str, shard_str);
-        match Self::get(&self, &request) {
+        let req = ClientRequest::StfState(getter, shard.to_owned());
+        //
+        // let getter_str = hex::encode(getter.encode());
+        // let shard_str = hex::encode(shard.encode());
+        // let request = format!("{}::{}::{}", MSG_GET_STF_STATE, getter_str, shard_str);
+        match Self::get(&self, req) {
             Ok(res) => {
                 let value_slice = hex::decode(&res).unwrap();
                 let value: Option<Vec<u8>> = Decode::decode(&mut &value_slice[..]).unwrap();
@@ -77,16 +79,15 @@ impl Api {
         }
     }
 
-    fn get(&self, request: &str) -> Result<String, ()> {
+    fn get(&self, request: ClientRequest) -> Result<String, ()> {
         let url = self.url.clone();
-        let req = request.to_string();
         let (port_in, port_out) = channel();
 
-        info!("[Worker Api]: Sending request: {}", req);
+        info!("[Worker Api]: Sending request: {:?}", request);
         let client = thread::spawn(move || {
             match connect(url, |out| WsClient {
                 out,
-                request: req.clone(),
+                request: request.clone(),
                 result: port_in.clone(),
             }) {
                 Ok(c) => c,

--- a/worker/worker-api/src/requests.rs
+++ b/worker/worker-api/src/requests.rs
@@ -17,11 +17,6 @@
 
 use codec::{Encode, Decode};
 use substratee_stf::{TrustedGetterSigned, ShardIdentifier};
-use std::sync::mpsc::Sender;
-
-pub const MSG_GET_PUB_KEY_WORKER: &str = "get_pub_key_worker";
-pub const MSG_GET_MU_RA_PORT: &str = "get_mu_ra_port";
-pub const MSG_GET_STF_STATE: &str = "get_stf_state";
 
 #[derive(Encode, Decode, Clone, Debug)]
 pub enum ClientRequest {

--- a/worker/worker-api/src/requests.rs
+++ b/worker/worker-api/src/requests.rs
@@ -15,6 +15,17 @@
 
 */
 
+use codec::{Encode, Decode};
+use substratee_stf::{TrustedGetterSigned, ShardIdentifier};
+use std::sync::mpsc::Sender;
+
 pub const MSG_GET_PUB_KEY_WORKER: &str = "get_pub_key_worker";
 pub const MSG_GET_MU_RA_PORT: &str = "get_mu_ra_port";
 pub const MSG_GET_STF_STATE: &str = "get_stf_state";
+
+#[derive(Encode, Decode, Clone, Debug)]
+pub enum ClientRequest {
+    PubKeyWorker,
+    MuRaPortWorker,
+    StfState(TrustedGetterSigned, ShardIdentifier), // (trusted_getter_encrypted, shard)
+}


### PR DESCRIPTION
* Restructured ws_server to hanlde messages in worker main loop to prevent race conditions to chain_relay_db and enclave state access
* [WorkerApi] get rid of string api and use proper `ClientRequest` enum