### PR TITLE
store only header hashes in chain relay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@
 # binaries
 bin/*.so
 bin/substratee-*
+bin/encointer-*
 bin/*.wasm
+bin2/encointer-*
 
 # sealed data
 bin/*.bin

--- a/enclave/chain_relay/src/lib.rs
+++ b/enclave/chain_relay/src/lib.rs
@@ -116,7 +116,7 @@ impl LightValidation {
 
         if grandpa_proof.is_none() {
             relay.last_finalized_block_header = header.clone();
-            relay.unjustified_headers.push(header);
+            relay.unjustified_headers.push(header.hash());
             info!(
                 "Syncing finalized block without grandpa proof. Amount of unjustified headers: {}",
                 relay.unjustified_headers.len()
@@ -142,8 +142,8 @@ impl LightValidation {
         Self::schedule_validator_set_change(&mut relay, &header);
 
         // a valid grandpa proof proofs finalization of all previous unjustified blocks
-        relay.headers.append(&mut relay.unjustified_headers);
-        relay.headers.push(header);
+        relay.header_hashes.append(&mut relay.unjustified_headers);
+        relay.header_hashes.push(header.hash());
 
         if validator_set_id > relay.current_validator_set_id {
             relay.current_validator_set = validator_set;
@@ -241,7 +241,7 @@ impl LightValidation {
             .tracked_relays
             .get(&relay_id)
             .ok_or(Error::NoSuchRelayExists)?;
-        Ok(relay.headers[0].hash())
+        Ok(relay.header_hashes[0])
     }
 
     pub fn latest_header(&self, relay_id: RelayId) -> Result<Header, Error> {

--- a/enclave/chain_relay/src/state.rs
+++ b/enclave/chain_relay/src/state.rs
@@ -10,8 +10,8 @@ pub struct RelayState<Block: BlockT> {
     pub last_finalized_block_header: Block::Header,
     pub current_validator_set: AuthorityList,
     pub current_validator_set_id: SetId,
-    pub headers: Vec<Block::Header>,
-    pub unjustified_headers: Vec<Block::Header>, // Finalized headers without grandpa proof
+    pub header_hashes: Vec<Block::Hash>,
+    pub unjustified_headers: Vec<Block::Hash>, // Finalized headers without grandpa proof
     pub verify_tx_inclusion: Vec<OpaqueExtrinsic>, // Transactions sent by the relay
     pub scheduled_change: Option<ScheduledChangeAtBlock<Block::Header>>, // Scheduled Authorities change as indicated in the header's digest.
 }
@@ -28,7 +28,7 @@ impl<Block: BlockT> RelayState<Block> {
             last_finalized_block_header: block_header.clone(),
             current_validator_set: validator_set,
             current_validator_set_id: 0,
-            headers: vec![block_header],
+            header_hashes: vec![block_header.hash()],
             unjustified_headers: Vec::new(),
             verify_tx_inclusion: Vec::new(),
             scheduled_change: None,


### PR DESCRIPTION
* only store the headers' hashes in chain_relay to save space

@brenzi I currently have problems with my environment. I could build but I can't currently instantiate an enclave. So this is untested. I try to fix the environment tomorrow. If you are eager you can test already.